### PR TITLE
Linkercommon

### DIFF
--- a/linker_common.R
+++ b/linker_common.R
@@ -2,5 +2,14 @@
 #' @param linkerSequence, vector of linker sequences
 #' @return linkerCommon, vector of the sequence after N
 linker_common <- function(linkerSequence) {
-    return(linkerSequence)
+    stopifnot(require("Biostrings"))
+    splited <- strsplit(linkerSequence, 'N+')
+    stopifnot(sapply(splited, length) == 2)
+    afterN <- sapply(splited, "[[", 2)
+    stopifnot(length(afterN)==length(linkerSequence))
+    
+    afterN_RCed <- unlist(lapply(afterN, function(x) as.character(reverseComplement(DNAString(x)))))
+    stopifnot(length(afterN_RCed)==length(linkerSequence))
+    
+    return(afterN_RCed)
 }

--- a/linker_common.R
+++ b/linker_common.R
@@ -1,0 +1,6 @@
+#' extract the second part of sequence of the linker sequence
+#' @param linkerSequence, vector of linker sequences
+#' @return linkerCommon, vector of the sequence after N
+linker_common <- function(linkerSequence) {
+    return(linkerSequence)
+}

--- a/linker_common.R
+++ b/linker_common.R
@@ -3,6 +3,7 @@
 #' @return linkerCommon, vector of the sequence after N
 linker_common <- function(linkerSequence) {
     stopifnot(require("Biostrings"))
+    stopifnot(is.character(linkerSequence))
     splited <- strsplit(linkerSequence, 'N+')
     stopifnot(sapply(splited, length) == 2)
     afterN <- sapply(splited, "[[", 2)

--- a/tests/test_calculate_linker_common.R
+++ b/tests/test_calculate_linker_common.R
@@ -1,0 +1,24 @@
+library(testthat)
+source("../linker_common.R")
+
+linker_input <- c(
+    "CGCCAACGTAGCGTTGCACNNNNNNNNNNNNCTCCGCTTAAGGGACT",
+    "GACGCGTAAGGTCGGGTAGNNNNNNNNNNNNCTCCGCTTAAGGGACT"
+    )
+
+expected_linker_common_output <- c("AGTCCCTTAAGCGGAG", "AGTCCCTTAAGCGGAG")
+
+test_that("Second sequence after N", {
+    expect_equal(expected_linker_common_output, linker_common(linker_input) )
+})
+
+
+linker_noN_input <- c(
+    "CGCCAACGTAGCGTTGCACCTCCGCTTAAGGGACT",
+    "GACGCGTAAGGTCGGGTAGCTCCGCTTAAGGGACT"
+    )
+
+test_that("Fail if no N in the middle", {
+    expect_error(linker_common(linker_noN_input))
+})
+

--- a/tests/test_calculate_linker_common.R
+++ b/tests/test_calculate_linker_common.R
@@ -3,22 +3,33 @@ source("../linker_common.R")
 
 linker_input <- c(
     "CGCCAACGTAGCGTTGCACNNNNNNNNNNNNCTCCGCTTAAGGGACT",
-    "GACGCGTAAGGTCGGGTAGNNNNNNNNNNNNCTCCGCTTAAGGGACT"
-    )
+    "GACGCGTAAGGTCGGGTAGNNNNNNNNNNNNCTCCGCTTAAGGGACT" )
+    
 
 expected_linker_common_output <- c("AGTCCCTTAAGCGGAG", "AGTCCCTTAAGCGGAG")
 
-test_that("Second sequence after N", {
+test_that("Reverse complement of the sequence after N", {
     expect_equal(expected_linker_common_output, linker_common(linker_input) )
+})
+
+test_that("Reverse complement of the sequence after N, vector of length 1", {
+    expect_equal(expected_linker_common_output[1], linker_common(linker_input[1]) )
 })
 
 
 linker_noN_input <- c(
     "CGCCAACGTAGCGTTGCACCTCCGCTTAAGGGACT",
-    "GACGCGTAAGGTCGGGTAGCTCCGCTTAAGGGACT"
-    )
+    "GACGCGTAAGGTCGGGTAGCTCCGCTTAAGGGACT" )
 
 test_that("Fail if no N in the middle", {
+    expect_error(linker_common(linker_noN_input))
+})
+
+linker_moreN_input <- c(
+    "CGCCAACGTAGCGNNNTTGCACCTCNCGCTTAAGGGACT",
+    "GACGCGTAAGGTCGGGTAGCTCCGCTTAAGGGACT" )
+
+test_that("Fail if more N in the middle", {
     expect_error(linker_common(linker_noN_input))
 })
 


### PR DESCRIPTION
Function linker_common() should work now. It grabs the second parts of the linkers and then reverse complement them. The tests compared the linker sequences and the linkercommon sequences from Eric's sampleInfo.csv and processingParams.csv files and all tests passed. 
